### PR TITLE
AVCodecContext::set_codecpar -> apply_codecpar

### DIFF
--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -241,7 +241,7 @@ impl AVCodecContext {
     /// of the corresponding field in `codecpar`. Fields in current
     /// `AVCodecContext` that do not have a counterpart in given `codecpar` are
     /// not touched.
-    pub fn set_codecpar(&mut self, codecpar: AVCodecParametersRef) -> Result<()> {
+    pub fn apply_codecpar(&mut self, codecpar: AVCodecParametersRef) -> Result<()> {
         unsafe { ffi::avcodec_parameters_to_context(self.as_mut_ptr(), codecpar.as_ptr()) }
             .upgrade()
             .map_err(|_| RsmpegError::CodecSetParameterError)?;

--- a/tests/extract_mvs.rs
+++ b/tests/extract_mvs.rs
@@ -59,7 +59,7 @@ fn extract_mvs(video_path: &CStr) -> Result<Vec<MotionVector>> {
 
         let mut decode_context = AVCodecContext::new(&decoder);
 
-        decode_context.set_codecpar(stream.codecpar())?;
+        decode_context.apply_codecpar(stream.codecpar())?;
 
         let key = cstr!("flags2");
         let value = cstr!("+export_mvs");

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -48,7 +48,7 @@ fn metadata(file: &str) -> Result<Vec<(String, String)>> {
         // Get `width` and `height` from `decode_context`
         let mut decode_context = AVCodecContext::new(&decoder);
         decode_context
-            .set_codecpar(video_stream.codecpar())
+            .apply_codecpar(video_stream.codecpar())
             .unwrap();
         decode_context.open(None).unwrap();
         result.push(("width".into(), decode_context.width.to_string()));

--- a/tests/thumbnail.rs
+++ b/tests/thumbnail.rs
@@ -29,7 +29,7 @@ fn thumbnail(
         let stream = input_format_context.streams().get(stream_index).unwrap();
 
         let mut decode_context = AVCodecContext::new(&decoder);
-        decode_context.set_codecpar(stream.codecpar())?;
+        decode_context.apply_codecpar(stream.codecpar())?;
         decode_context.open(None)?;
 
         (stream_index, decode_context)

--- a/tests/transcode_aac.rs
+++ b/tests/transcode_aac.rs
@@ -27,7 +27,7 @@ fn open_input_file(input_file: &CStr) -> (AVFormatContextInput, AVCodecContext) 
 
     let mut decode_context = AVCodecContext::new(&decode_codec);
     decode_context
-        .set_codecpar(input_format_context.streams().get(0).unwrap().codecpar())
+        .apply_codecpar(input_format_context.streams().get(0).unwrap().codecpar())
         .unwrap();
     decode_context.open(None).unwrap();
     (input_format_context, decode_context)

--- a/tests/transcoding.rs
+++ b/tests/transcoding.rs
@@ -34,7 +34,7 @@ fn open_input_file(filename: &CStr) -> Result<(AVFormatContextInput, Vec<StreamC
             .with_context(|| anyhow!("decoder ({}) not found.", codec_id))?;
 
         let mut decode_context = AVCodecContext::new(&decoder);
-        decode_context.set_codecpar(input_stream.codecpar())?;
+        decode_context.apply_codecpar(input_stream.codecpar())?;
 
         if decode_context.codec_type == ffi::AVMediaType_AVMEDIA_TYPE_VIDEO {
             if let Some(framerate) = input_stream.guess_framerate() {

--- a/tests/tutorial01.rs
+++ b/tests/tutorial01.rs
@@ -62,7 +62,7 @@ fn _main(file: &CStr, out_dir: &str) -> Result<()> {
         let decoder = AVCodec::find_decoder(video_stream.codecpar().codec_id)
             .context("Cannot find the decoder for video stream")?;
         let mut decode_context = AVCodecContext::new(&decoder);
-        decode_context.set_codecpar(video_stream.codecpar())?;
+        decode_context.apply_codecpar(video_stream.codecpar())?;
         decode_context.open(None)?;
         decode_context
     };


### PR DESCRIPTION
There is no `codecpar` field in `AVCodecContext`, so `apply_codecpar` is more
appropriate.