### PR TITLE
Remove `AVFrameWithSamples`

### DIFF
--- a/src/avutil/frame.rs
+++ b/src/avutil/frame.rs
@@ -48,15 +48,21 @@ impl AVFrame {
     /// Allocate new buffer(s) for audio or video data.
     /// The following fields must be set on frame before calling this function:
     ///
-    /// - format (pixel format for video, sample format for audio)
-    /// - width and height for video
-    /// - nb_samples and channel_layout for audio
+    /// Video:
+    /// - format (pixel format)
+    /// - width
+    /// - height
+    ///
+    /// Audio:
+    /// - format (sample format)
+    /// - nb_samples
+    /// - channel_layout or channels
     ///
     /// Return Error when the some of the frame settings are invalid, allocating
     /// buffer for an already initialized frame or allocation fails because of
     /// no memory.
     pub fn alloc_buffer(&mut self) -> Result<()> {
-        // If frame already has been allocated, calling av_frame_get_buffer will
+        // If frame has already been allocated, calling av_frame_get_buffer will
         // leak memory. So we do a check here.
         if self.is_allocated() {
             return Err(RsmpegError::AVFrameDoubleAllocatingError);

--- a/src/avutil/frame.rs
+++ b/src/avutil/frame.rs
@@ -1,5 +1,5 @@
 use crate::{
-    avutil::{av_image_fill_arrays, AVImage, AVMotionVector, AVPixelFormat, AVSamples},
+    avutil::{av_image_fill_arrays, AVImage, AVMotionVector, AVPixelFormat},
     error::*,
     ffi,
     shared::*,
@@ -197,68 +197,6 @@ impl AVFrameWithImage {
     /// Convert `self` into an [`AVImage`] instance.
     pub fn into_image(self) -> AVImage {
         self.image
-    }
-}
-
-/// It's a `AVFrame` binded with `AVImage`, the `AVFrame` references the buffer
-/// of the `AVImage`.
-pub struct AVFrameWithSamples {
-    frame: AVFrame,
-    samples: AVSamples,
-}
-
-impl std::ops::Deref for AVFrameWithSamples {
-    type Target = AVFrame;
-    fn deref(&self) -> &Self::Target {
-        &self.frame
-    }
-}
-
-impl std::ops::DerefMut for AVFrameWithSamples {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.frame
-    }
-}
-
-impl AVFrameWithSamples {
-    /// Create a [`AVFrame`] instance and wrap it with the given [`AVSamples`]
-    /// into a [`AVFrameWithSamples`]. The created frame instance uses the buffer
-    /// of given [`AVSamples`], and is initialized with the parameter of the given
-    /// [`AVSamples`]. You can get the inner frame instance by derefenceing. You
-    /// can get the inner samples instance by [`Self::samples()`].
-    ///
-    /// This function takes metadata from [`AVSamples`] and store them in the frame.
-    /// Metadata list:
-    /// ```txt
-    /// frame.data <= samples.audio_data
-    /// frame.linesize[0] <= samples.line_size
-    /// frame.format <= samples.sample_fmt
-    /// frame.nb_samples <= samples.nb_samples
-    /// ```
-    pub fn new(samples: AVSamples, sample_rate: i32, channel_layout: u64) -> Self {
-        let mut frame = AVFrame::new();
-        unsafe {
-            // Borrow the image buffer.
-            let nb_channel = frame.data.len().min(samples.audio_data.len());
-            frame.deref_mut().data[0..nb_channel]
-                .copy_from_slice(&samples.audio_data[0..nb_channel]);
-            frame.deref_mut().linesize[0] = samples.linesize;
-            frame.deref_mut().sample_rate = sample_rate;
-            frame.deref_mut().channel_layout = channel_layout;
-            frame.deref_mut().format = samples.sample_fmt;
-            frame.deref_mut().nb_samples = samples.nb_samples;
-        }
-        Self { frame, samples }
-    }
-
-    /// Get reference to inner [`AVSamples`] instance.
-    pub fn samples(&self) -> &AVSamples {
-        &self.samples
-    }
-
-    /// Convert `self` into an [`AVSamples`] instance.
-    pub fn into_samples(self) -> AVSamples {
-        self.samples
     }
 }
 

--- a/src/avutil/samplefmt.rs
+++ b/src/avutil/samplefmt.rs
@@ -110,6 +110,16 @@ pub fn is_planar(sample_fmt: AVSampleFormat) -> bool {
 // The `nb_samples` of `AVSamples` is the capacity rather than length.
 // `nb_channels` and `audio_data.len()`(which is nb_planes) is only the same
 // when the audio sample format in planar.
+//
+//
+// Check the documentation of `AVFrame::extended_data`:
+//
+// > Note: Both data and extended_data should always be set in a valid frame,
+// > but for planar audio with more channels that can fit in data,
+// > extended_data must be used in order to access all channels.
+//
+// This is the reason why `AVSamples` has a vector of channels for containing
+// audio data.
 wrap! {
     AVSamples: Vec<u8>,
     audio_data: Vec<*mut u8> = Vec::new(),
@@ -160,6 +170,8 @@ impl AVSamples {
     /// sample_fmt          Audio sample formats
     /// align               buffer size alignment (0 = default, 1 = no alignment)
     /// ```
+    ///
+    /// Return `None` on invalid parameters, panic on no memory.
     pub fn new(
         nb_channels: i32,
         nb_samples: i32,


### PR DESCRIPTION
It's not a good design. `Samples`'s data may have more than 8 channels(placed in `extended_data`), which makes it cannot share data with `AVFrame` easily & safely.