### PR TITLE
Comply with the MSRV, less panic in avio_writing test

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-imports_granularity = "Crate"


### PR DESCRIPTION
`imports_granularity` is not supported in stable channel. -_-b