### PR TITLE
Allow `AVFilterGraph::parse_ptr` accept no inputs or no outputs.

### DIFF
--- a/tests/transcoding.rs
+++ b/tests/transcoding.rs
@@ -221,7 +221,7 @@ fn init_filter<'graph>(
     // Yes the outputs' name is `in` -_-b
     let outputs = AVFilterInOut::new(cstr!("in"), &mut buffer_src_context, 0);
     let inputs = AVFilterInOut::new(cstr!("out"), &mut buffer_sink_context, 0);
-    let (_inputs, _outputs) = filter_graph.parse_ptr(filter_spec, inputs, outputs)?;
+    let (_inputs, _outputs) = filter_graph.parse_ptr(filter_spec, Some(inputs), Some(outputs))?;
 
     filter_graph.config()?;
 


### PR DESCRIPTION
Closes #56 again