### PR TITLE
Use explicit lifetime instead of 'static for custom IO context

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,16 +4,16 @@
 /// Wrapping with XXX -> XXX mapping.
 macro_rules! wrap_pure {
     (
-        ($wrapped_type: ident): $ffi_type: ty
+        ($wrapped_type: ident)$(<$lt:lifetime>)?: $ffi_type: ty
         $(,$attach: ident: $attach_type: ty = $attach_default: expr)*
     ) => {
-        pub struct $wrapped_type {
+        pub struct $wrapped_type$(<$lt>)? {
             something_should_not_be_touched_directly: std::ptr::NonNull<$ffi_type>,
             // Publicize the attachment, can be directly changed without deref_mut()
             $(pub $attach: $attach_type,)*
         }
 
-        impl $wrapped_type {
+        impl$(<$lt>)? $wrapped_type$(<$lt>)? {
             pub fn as_ptr(&self) -> *const $ffi_type {
                 self.something_should_not_be_touched_directly.as_ptr() as *const _
             }
@@ -50,7 +50,7 @@ macro_rules! wrap_pure {
             }
         }
 
-        impl std::ops::Deref for $wrapped_type {
+        impl$(<$lt>)? std::ops::Deref for $wrapped_type$(<$lt>)? {
             type Target = $ffi_type;
 
             fn deref(&self) -> &Self::Target {
@@ -58,13 +58,13 @@ macro_rules! wrap_pure {
             }
         }
 
-        impl crate::shared::UnsafeDerefMut for $wrapped_type {
+        impl$(<$lt>)? crate::shared::UnsafeDerefMut for $wrapped_type$(<$lt>)? {
             unsafe fn deref_mut(&mut self) -> &mut Self::Target {
                 unsafe { self.something_should_not_be_touched_directly.as_mut() }
             }
         }
 
-        unsafe impl Send for $wrapped_type {}
+        unsafe impl$(<$lt>)? Send for $wrapped_type$(<$lt>)? {}
     };
 }
 
@@ -191,11 +191,11 @@ macro_rules! wrap_mut {
 /// Wrapping with XXX, XXX -> XXX.
 macro_rules! wrap {
     (
-        $name: ident: $ffi_type: ty
+        $name: ident$(<$lt:lifetime>)?: $ffi_type: ty
         $(,$attach: ident: $attach_type: ty = $attach_default: expr)* $(,)?
     ) => {
         paste::paste! {
-            wrap_pure!(($name): $ffi_type $(,$attach: $attach_type = $attach_default)*);
+            wrap_pure!(($name)$(<$lt>)?: $ffi_type $(,$attach: $attach_type = $attach_default)*);
         }
     };
 }

--- a/tests/avio_writing.rs
+++ b/tests/avio_writing.rs
@@ -45,10 +45,10 @@ fn open_input_file(filename: &CStr) -> Result<(usize, AVFormatContextInput, AVCo
 }
 
 /// Return output_format_context and encode_context
-fn open_output_file(
+fn open_output_file<'a>(
     filename: &CStr,
     decode_context: &AVCodecContext,
-) -> Result<(AVFormatContextOutput, AVCodecContext)> {
+) -> Result<(AVFormatContextOutput<'a>, AVCodecContext)> {
     let buffer = Arc::new(Mutex::new(File::create(filename.to_str()?)?));
     let buffer1 = buffer.clone();
 

--- a/tests/transcode_aac.rs
+++ b/tests/transcode_aac.rs
@@ -30,10 +30,10 @@ fn open_input_file(input_file: &CStr) -> Result<(AVFormatContextInput, AVCodecCo
     Ok((input_format_context, decode_context, audio_index))
 }
 
-fn open_output_file(
+fn open_output_file<'a>(
     output_file: &CStr,
     decode_context: &AVCodecContext,
-) -> Result<(AVFormatContextOutput, AVCodecContext)> {
+) -> Result<(AVFormatContextOutput<'a>, AVCodecContext)> {
     // Create a new format context for the output container format.
     let mut output_format_context =
         AVFormatContextOutput::create(output_file, None).context("Failed to open output file.")?;

--- a/tests/transcoding.rs
+++ b/tests/transcoding.rs
@@ -77,11 +77,11 @@ fn open_input_file(filename: &CStr) -> Result<(Vec<Option<AVCodecContext>>, AVFo
 /// Accepts a output filename, attach `encode_context` to the corresponding
 /// `decode_context` and wrap them into a `stream_context`. `stream_context` is
 /// None when the given `decode_context` in the same index is None.
-fn open_output_file(
+fn open_output_file<'a>(
     filename: &CStr,
     decode_contexts: Vec<Option<AVCodecContext>>,
     dict: &mut Option<AVDictionary>,
-) -> Result<(Vec<Option<StreamContext>>, AVFormatContextOutput)> {
+) -> Result<(Vec<Option<StreamContext>>, AVFormatContextOutput<'a>)> {
     let mut output_format_context = AVFormatContextOutput::create(filename, None)?;
     let mut stream_contexts = vec![];
 


### PR DESCRIPTION
I'd like to decode incoming HTTP buffers, which are not necessarily contiguous but do support the `bytes::Buf` protocol, using a `AVIOContextCustom`.

However, the read/send/seek callbacks associated with the context require that all data associated with them be `Send + 'static`, which limits the ability to parse data out of buffers without needing to copy.

For example, I would like to be able to create the following custom context:
```rust
/// Creates a [`AVIOContextCustom`] from an encoded video file.
/// This is streaming compatible and does not support seeking.
fn create_io_context<'a>(mut video_data: impl Buf + Send + 'a) -> AVIOContextCustom<'a> {
    let video_data_len = video_data.remaining();
    let buffer = AVMem::new(16384);
    let mut read_pos = 0;
    AVIOContextCustom::alloc_context(
        buffer,
        false,
        vec![],
        Some(Box::new(move |_, dest| {
            let end_pos = video_data_len.min(read_pos + dest.len());
            if end_pos <= read_pos {
                return ffi::AVERROR_EOF;
            }
            let read_len = end_pos - read_pos;
            let chunk = video_data.chunk();
            let bytes_read = read_len.min(chunk.len());
            dest[0..bytes_read].copy_from_slice(&chunk[..bytes_read]);
            video_data.advance(bytes_read);
            read_pos += bytes_read;
            bytes_read as i32
        })),
        None,
        None,
    )
}
```
This changes the API allow an explicit lifetime for data in the context, rather than requiring `'static`. This would, of course, break backwards compatibility, but it has been extremely useful for my own work at least, avoiding an extra copy into a coalesced `Bytes` object or similar.