### PR TITLE
Remove deprecated methods

### DIFF
--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -126,11 +126,6 @@ impl<'codec> AVCodec {
         // terminates with -1
         Self::build_array(self.sample_fmts, -1)
     }
-
-    pub fn channel_layouts(&'codec self) -> Option<&'codec [u64]> {
-        // terminates with -1
-        Self::build_array(self.channel_layouts, 0)
-    }
 }
 
 impl Drop for AVCodec {
@@ -151,7 +146,6 @@ settable!(AVCodecContext {
     time_base: AVRational,
     pkt_timebase: AVRational,
     sample_rate: i32,
-    channels: i32,
     sample_fmt: i32,
     flags: i32,
     bit_rate: i64,

--- a/src/avformat/avformat.rs
+++ b/src/avformat/avformat.rs
@@ -508,13 +508,6 @@ impl AVStream {
             ffi::av_guess_frame_rate(ptr::null_mut(), self.as_ptr() as *mut _, ptr::null_mut())
         })
     }
-
-    /// Returns the pts of the last muxed packet + its duration
-    /// the returned value is None when used with a demuxer.
-    pub fn get_end_pts(&self) -> Option<i64> {
-        let result = unsafe { ffi::av_stream_get_end_pts(self.as_ptr()) };
-        (result >= 0).then_some(result)
-    }
 }
 
 impl<'stream> AVStream {


### PR DESCRIPTION
Several methods and field is completely removed in FFmpeg 7.0. Remove them in advance.