### PR TITLE
Check `target_env = msvc` instead of `windows` for correct `codec_id` type

### DIFF
--- a/src/avcodec/parser.rs
+++ b/src/avcodec/parser.rs
@@ -10,7 +10,7 @@ wrap!(AVCodecParserContext: ffi::AVCodecParserContext);
 impl AVCodecParserContext {
     /// Allocate a [`AVCodecParserContext`] with given [`AVCodecID`].
     pub fn init(codec_id: AVCodecID) -> Option<Self> {
-        // On Windows enum is i32, On *nix enum is u32.
+        // For MSVC enum is i32, otherwises enum is u32.
         // ref: https://github.com/rust-lang/rust-bindgen/issues/1361
         #[cfg(not(target_env = "msvc"))]
         let codec_id = codec_id as i32;

--- a/src/avcodec/parser.rs
+++ b/src/avcodec/parser.rs
@@ -12,7 +12,7 @@ impl AVCodecParserContext {
     pub fn init(codec_id: AVCodecID) -> Option<Self> {
         // On Windows enum is i32, On *nix enum is u32.
         // ref: https://github.com/rust-lang/rust-bindgen/issues/1361
-        #[cfg(not(windows))]
+        #[cfg(not(target_env = "msvc"))]
         let codec_id = codec_id as i32;
         unsafe { ffi::av_parser_init(codec_id) }
             .upgrade()


### PR DESCRIPTION
This PR makes `rsmpeg` compile on `x86_64-pc-windows-gnu`. (See https://github.com/Yesterday17/iori/pull/19/commits/2367cbd75433b4ca8461c4c4465c695e34a9d38f)