### PR TITLE
[WIP] Fixed build when using vcpkg linking updating ffmpeg APIs references

### DIFF
--- a/src/avcodec/bitstream.rs
+++ b/src/avcodec/bitstream.rs
@@ -9,6 +9,13 @@ use std::{
     ptr::{self, NonNull},
 };
 
+#[repr(C)]
+struct AVBitStreamFilterRepr {
+    name: *const std::os::raw::c_char,
+    codec_ids: *const ffi::AVCodecID,
+    priv_class: *const ffi::AVClass,
+}
+
 wrap_ref!(AVBitStreamFilter: ffi::AVBitStreamFilter);
 
 impl AVBitStreamFilter {
@@ -21,9 +28,8 @@ impl AVBitStreamFilter {
 
     /// Get name of the bitstream filter.
     pub fn name(&self) -> &CStr {
-        // We assume name is always NonNull, so we do check here.
-        let name = NonNull::new(self.name as *mut _).unwrap();
-        unsafe { CStr::from_ptr(name.as_ptr()) }
+        let repr = self.as_ptr() as *const AVBitStreamFilterRepr;
+        unsafe { CStr::from_ptr((*repr).name) }
     }
 
     /// Create an iterator on all the [`AVBitStreamFilterRef`]s.

--- a/src/avformat/avformat.rs
+++ b/src/avformat/avformat.rs
@@ -15,6 +15,7 @@ use crate::{
     shared::*,
 };
 
+// Mirrors avformat.h:1269-1501 (FFmpeg 8)
 #[repr(C)]
 struct AVFormatContextRepr {
     av_class: *const ffi::AVClass,

--- a/src/avformat/avformat.rs
+++ b/src/avformat/avformat.rs
@@ -293,6 +293,24 @@ impl<'stream> AVFormatContextInput {
         let repr = self.as_ptr() as *const AVFormatContextRepr;
         unsafe { NonNull::new((*repr).metadata).map(|x| AVDictionaryRef::from_raw(x)) }
     }
+
+    /// Get number of streams.
+    pub fn nb_streams(&self) -> u32 {
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { (*repr).nb_streams }
+    }
+
+    /// Get duration of the stream, in AV_TIME_BASE fractional seconds.
+    pub fn duration(&self) -> i64 {
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { (*repr).duration }
+    }
+
+    /// Get total stream bitrate in bit/s.
+    pub fn bit_rate(&self) -> i64 {
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { (*repr).bit_rate }
+    }
 }
 
 impl Drop for AVFormatContextInput {

--- a/src/avformat/avformat.rs
+++ b/src/avformat/avformat.rs
@@ -15,6 +15,40 @@ use crate::{
     shared::*,
 };
 
+#[repr(C)]
+struct AVFormatContextRepr {
+    av_class: *const ffi::AVClass,
+    iformat: *const ffi::AVInputFormat,
+    oformat: *const ffi::AVOutputFormat,
+    priv_data: *mut c_void,
+    pb: *mut ffi::AVIOContext,
+    ctx_flags: c_int,
+    nb_streams: std::os::raw::c_uint,
+    streams: *mut *mut ffi::AVStream,
+    nb_stream_groups: std::os::raw::c_uint,
+    stream_groups: *mut *mut ffi::AVStreamGroup,
+    nb_chapters: std::os::raw::c_uint,
+    chapters: *mut *mut ffi::AVChapter,
+    url: *mut std::os::raw::c_char,
+    start_time: i64,
+    duration: i64,
+    bit_rate: i64,
+    packet_size: std::os::raw::c_uint,
+    max_delay: c_int,
+    flags: c_int,
+    probesize: i64,
+    max_analyze_duration: i64,
+    key: *const u8,
+    keylen: c_int,
+    nb_programs: std::os::raw::c_uint,
+    programs: *mut *mut ffi::AVProgram,
+    video_codec_id: ffi::AVCodecID,
+    audio_codec_id: ffi::AVCodecID,
+    subtitle_codec_id: ffi::AVCodecID,
+    data_codec_id: ffi::AVCodecID,
+    metadata: *mut ffi::AVDictionary,
+}
+
 /// Container of all kinds of AVIOContexts.
 pub enum AVIOContextContainer {
     Url(AVIOContextURL),
@@ -73,7 +107,8 @@ impl AVFormatContextInput {
 
             if let Some(io_context) = io_context.as_mut() {
                 unsafe {
-                    (*input_format_context).pb = match io_context {
+                    let repr = input_format_context as *mut AVFormatContextRepr;
+                    (*repr).pb = match io_context {
                         AVIOContextContainer::Url(ctx) => ctx.as_mut_ptr(),
                         AVIOContextContainer::Custom(ctx) => ctx.as_mut_ptr(),
                     };
@@ -208,22 +243,14 @@ impl AVFormatContextInput {
 impl<'stream> AVFormatContextInput {
     /// Return slice of [`AVStreamRef`].
     pub fn streams(&'stream self) -> &'stream [AVStreamRef<'stream>] {
-        // #define `<->` as "has the same layout due to repr(transparent)"
-        // ```
-        // NonNull<ffi::AVStream> <-> *const ffi::AVStream
-        // AVStream <-> NonNull<ffi::AVStream>
-        // AVStreamRef <-> AVStream
-        // ```
-        // indicates: AVStreamRef <-> *const ffi::AVStream
-        let streams = self.streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
-        // u32 to usize, safe
-        let len = self.nb_streams as usize;
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        let streams = unsafe { (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream> };
+        let len = unsafe { (*repr).nb_streams as usize };
 
-        // I trust that FFmpeg won't give me null pointers :-(
         #[cfg(debug_assertions)]
         {
-            let arr = unsafe {
-                std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
+            let arr: &[*const ffi::AVStream] = unsafe {
+                std::slice::from_raw_parts((*repr).streams as *const *const ffi::AVStream, len)
             };
             for ptr in arr {
                 assert!(!ptr.is_null());
@@ -235,22 +262,14 @@ impl<'stream> AVFormatContextInput {
 
     /// Return slice of [`AVStreamMut`].
     pub fn streams_mut(&'stream mut self) -> &'stream mut [AVStreamMut<'stream>] {
-        // #define `<->` as "has the same layout due to repr(transparent)"
-        // ```
-        // NonNull<ffi::AVStream> <-> *const ffi::AVStream
-        // AVStream <-> NonNull<ffi::AVStream>
-        // AVStreamMut <-> AVStream
-        // ```
-        // indicates: AVStreamMut <-> *const ffi::AVStream
-        let streams = self.streams as *mut AVStreamMut<'stream>;
-        // u32 to usize, safe
-        let len = self.nb_streams as usize;
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        let streams = unsafe { (*repr).streams as *mut AVStreamMut<'stream> };
+        let len = unsafe { (*repr).nb_streams as usize };
 
-        // I trust that FFmpeg won't give me null pointers :-(
         #[cfg(debug_assertions)]
         {
-            let arr = unsafe {
-                std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
+            let arr: &[*const ffi::AVStream] = unsafe {
+                std::slice::from_raw_parts((*repr).streams as *const *const ffi::AVStream, len)
             };
             for ptr in arr {
                 assert!(!ptr.is_null());
@@ -262,19 +281,16 @@ impl<'stream> AVFormatContextInput {
 
     /// Get [`AVInputFormatRef`] in the [`AVFormatContextInput`].
     pub fn iformat(&'stream self) -> AVInputFormatRef<'stream> {
-        // From the implementation of FFmpeg's `avformat_open_input`, we can be
-        // sure that iformat won't be null when demuxing.
-        unsafe { AVInputFormatRef::from_raw(NonNull::new(self.iformat as *mut _).unwrap()) }
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { AVInputFormatRef::from_raw(NonNull::new((*repr).iformat as *mut _).unwrap()) }
     }
 
     /// Get metadata of the [`ffi::AVFormatContext`] in [`crate::avutil::AVDictionary`].
     /// demuxing: set by libavformat in `avformat_open_input()`
     /// muxing: may be set by the caller before `avformat_write_header()`
     pub fn metadata(&'stream self) -> Option<AVDictionaryRef<'stream>> {
-        // From implementation:
-        // `avformat_find_stream_info()->()read_frame_internal()`, we know
-        // `metadata` can be null.
-        NonNull::new(self.metadata).map(|x| unsafe { AVDictionaryRef::from_raw(x) })
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { NonNull::new((*repr).metadata).map(|x| AVDictionaryRef::from_raw(x)) }
     }
 }
 
@@ -356,7 +372,8 @@ impl AVFormatContextOutput {
             };
             if let Some(mut io_context) = io_context {
                 unsafe {
-                    output_format_context.deref_mut().pb = io_context.as_mut_ptr();
+                    let repr = output_format_context.as_mut_ptr() as *mut AVFormatContextRepr;
+                    (*repr).pb = io_context.as_mut_ptr();
                 }
                 output_format_context.io_context = Some(io_context);
             }
@@ -436,22 +453,14 @@ impl AVFormatContextOutput {
 impl<'stream> AVFormatContextOutput {
     /// Return slice of [`AVStreamRef`].
     pub fn streams(&'stream self) -> &'stream [AVStreamRef<'stream>] {
-        // #define `<->` as "has the same layout due to repr(transparent)"
-        // ```
-        // NonNull<ffi::AVStream> <-> *const ffi::AVStream
-        // AVStream <-> NonNull<ffi::AVStream>
-        // AVStreamRef <-> AVStream
-        // ```
-        // indicates: AVStreamRef <-> *const ffi::AVStream
-        let streams = self.streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
-        // u32 to usize, safe
-        let len = self.nb_streams as usize;
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        let streams = unsafe { (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream> };
+        let len = unsafe { (*repr).nb_streams as usize };
 
-        // I trust that FFmpeg won't give me null pointers :-(
         #[cfg(debug_assertions)]
         {
-            let arr = unsafe {
-                std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
+            let arr: &[*const ffi::AVStream] = unsafe {
+                std::slice::from_raw_parts((*repr).streams as *const *const ffi::AVStream, len)
             };
             for ptr in arr {
                 assert!(!ptr.is_null());
@@ -463,16 +472,15 @@ impl<'stream> AVFormatContextOutput {
 
     /// Get [`AVOutputFormat`] from the [`AVFormatContextOutput`].
     pub fn oformat(&self) -> AVOutputFormatRef<'static> {
-        // From the implementation of FFmpeg's `avformat_alloc_output_context2`,
-        // we can be sure that `oformat` won't be null when muxing.
-        unsafe { AVOutputFormatRef::from_raw(NonNull::new(self.oformat as *mut _).unwrap()) }
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        unsafe { AVOutputFormatRef::from_raw(NonNull::new((*repr).oformat as *mut _).unwrap()) }
     }
 
     /// Set [`AVOutputFormat`] in the [`AVFormatContextOutput`].
     pub fn set_oformat(&mut self, format: AVOutputFormatRef<'static>) {
-        // `as _` is for compatibility with older FFmpeg versions(< 5.0)
         unsafe {
-            self.deref_mut().oformat = format.as_ptr() as _;
+            let repr = self.as_mut_ptr() as *mut AVFormatContextRepr;
+            (*repr).oformat = format.as_ptr() as _;
         }
     }
 
@@ -491,10 +499,10 @@ impl<'stream> AVFormatContextOutput {
 
 impl Drop for AVFormatContextOutput {
     fn drop(&mut self) {
-        // Here we drop the io context, which won't be touched by
-        // avformat_free_context, so let it dangling is safe.
-        if unsafe { *self.oformat }.flags & ffi::AVFMT_NOFILE as i32 == 0 {
-            if let Some(pb) = NonNull::new(self.pb) {
+        let repr = self.as_ptr() as *const AVFormatContextRepr;
+        let oformat_ptr = unsafe { (*repr).oformat };
+        if unsafe { oformat_ptr.as_ref() }.unwrap().flags & ffi::AVFMT_NOFILE as i32 == 0 {
+            if let Some(pb) = unsafe { NonNull::new((*repr).pb) } {
                 let _ = unsafe { AVIOContext::from_raw(pb) };
             }
         }

--- a/src/avformat/avformat.rs
+++ b/src/avformat/avformat.rs
@@ -245,7 +245,9 @@ impl<'stream> AVFormatContextInput {
     /// Return slice of [`AVStreamRef`].
     pub fn streams(&'stream self) -> &'stream [AVStreamRef<'stream>] {
         let repr = self.as_ptr() as *const AVFormatContextRepr;
-        let streams = unsafe { (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream> };
+        let streams = unsafe {
+            (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>
+        };
         let len = unsafe { (*repr).nb_streams as usize };
 
         #[cfg(debug_assertions)]
@@ -473,7 +475,9 @@ impl<'stream> AVFormatContextOutput {
     /// Return slice of [`AVStreamRef`].
     pub fn streams(&'stream self) -> &'stream [AVStreamRef<'stream>] {
         let repr = self.as_ptr() as *const AVFormatContextRepr;
-        let streams = unsafe { (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream> };
+        let streams = unsafe {
+            (*repr).streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>
+        };
         let len = unsafe { (*repr).nb_streams as usize };
 
         #[cfg(debug_assertions)]

--- a/tests/ffmpeg_examples/transcode.rs
+++ b/tests/ffmpeg_examples/transcode.rs
@@ -37,7 +37,7 @@ struct FilterContext<'graph> {
 /// audio, decode context at this index is set to `None`.
 fn open_input_file(filename: &CStr) -> Result<(Vec<Option<AVCodecContext>>, AVFormatContextInput)> {
     let mut ifmt_ctx = AVFormatContextInput::open(filename)?;
-    let mut stream_ctx = Vec::with_capacity(ifmt_ctx.nb_streams as usize);
+    let mut stream_ctx = Vec::with_capacity(ifmt_ctx.nb_streams() as usize);
 
     for (i, input_stream) in ifmt_ctx.streams().into_iter().enumerate() {
         let codecpar = input_stream.codecpar();

--- a/tests/misc/metadata.rs
+++ b/tests/misc/metadata.rs
@@ -11,8 +11,8 @@ fn metadata(file: &str) -> Result<Vec<(String, String)>> {
     let input_format_context = AVFormatContextInput::open(&file).unwrap();
 
     // Get `duration` and `bit_rate` from `input_format_context`.
-    result.push(("duration".into(), input_format_context.duration.to_string()));
-    result.push(("bit_rate".into(), input_format_context.bit_rate.to_string()));
+    result.push(("duration".into(), input_format_context.duration().to_string()));
+    result.push(("bit_rate".into(), input_format_context.bit_rate().to_string()));
 
     // Get additional info from `input_format_context.metadata()`
     if let Some(metadata) = input_format_context.metadata() {

--- a/tests/misc/metadata.rs
+++ b/tests/misc/metadata.rs
@@ -11,8 +11,14 @@ fn metadata(file: &str) -> Result<Vec<(String, String)>> {
     let input_format_context = AVFormatContextInput::open(&file).unwrap();
 
     // Get `duration` and `bit_rate` from `input_format_context`.
-    result.push(("duration".into(), input_format_context.duration().to_string()));
-    result.push(("bit_rate".into(), input_format_context.bit_rate().to_string()));
+    result.push((
+        "duration".into(),
+        input_format_context.duration().to_string(),
+    ));
+    result.push((
+        "bit_rate".into(),
+        input_format_context.bit_rate().to_string(),
+    ));
 
     // Get additional info from `input_format_context.metadata()`
     if let Some(metadata) = input_format_context.metadata() {


### PR DESCRIPTION
I have not been able to compile master on Linux, which should correspond to the last released version, when linking through vcpkg. That was the output of cargo build:

```
Compiling rusty_ffmpeg v0.16.7+ffmpeg.8
   Compiling rsmpeg v0.18.0+ffmpeg.8.0 (/home/lorenzo/repository/rsmpeg)
error[E0615]: attempted to take value of method `name` on type `&bitstream::AVBitStreamFilter`
  --> src/avcodec/bitstream.rs:25:38
   |
25 |         let name = NonNull::new(self.name as *mut _).unwrap();
   |                                      ^^^^ method, not a field
   |
help: use parentheses to call the method
   |
25 |         let name = NonNull::new(self.name() as *mut _).unwrap();
   |                                          ++

error[E0609]: no field `pb` on type `AVFormatContext`
  --> src/avformat/avformat.rs:76:45
   |
76 |                     (*input_format_context).pb = match io_context {
   |                                             ^^ unknown field
   |
   = note: available field is: `_address`

error[E0615]: attempted to take value of method `streams` on type `&'stream AVFormatContextInput`
   --> src/avformat/avformat.rs:218:28
    |
218 |         let streams = self.streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
    |                            ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
218 |         let streams = self.streams() as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
    |                                   ++

error[E0609]: no field `nb_streams` on type `&'stream AVFormatContextInput`
   --> src/avformat/avformat.rs:220:24
    |
220 |         let len = self.nb_streams as usize;
    |                        ^^^^^^^^^^ unknown field
    |
    = note: available fields are: `something_should_not_be_touched_directly`, `io_context`
    = note: available field is: `_address`

error[E0615]: attempted to take value of method `streams` on type `&'stream AVFormatContextInput`
   --> src/avformat/avformat.rs:226:49
    |
226 |                 std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
    |                                                 ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
226 |                 std::slice::from_raw_parts(self.streams() as *const *const ffi::AVStream, len)
    |                                                        ++

error[E0282]: type annotations needed for `&[_]`
   --> src/avformat/avformat.rs:225:17
    |
225 |             let arr = unsafe {
    |                 ^^^
...
229 |                 assert!(!ptr.is_null());
    |                          --- type must be known at this point
    |
help: consider giving `arr` an explicit type, where the placeholders `_` are specified
    |
225 |             let arr: &[T] = unsafe {
    |                    ++++++

error[E0615]: attempted to take value of method `streams` on type `&'stream mut AVFormatContextInput`
   --> src/avformat/avformat.rs:245:28
    |
245 |         let streams = self.streams as *mut AVStreamMut<'stream>;
    |                            ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
245 |         let streams = self.streams() as *mut AVStreamMut<'stream>;
    |                                   ++

error[E0609]: no field `nb_streams` on type `&'stream mut AVFormatContextInput`
   --> src/avformat/avformat.rs:247:24
    |
247 |         let len = self.nb_streams as usize;
    |                        ^^^^^^^^^^ unknown field
    |
    = note: available fields are: `something_should_not_be_touched_directly`, `io_context`
    = note: available field is: `_address`

error[E0615]: attempted to take value of method `streams` on type `&'stream mut AVFormatContextInput`
   --> src/avformat/avformat.rs:253:49
    |
253 |                 std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
    |                                                 ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
253 |                 std::slice::from_raw_parts(self.streams() as *const *const ffi::AVStream, len)
    |                                                        ++

error[E0282]: type annotations needed for `&[_]`
   --> src/avformat/avformat.rs:252:17
    |
252 |             let arr = unsafe {
    |                 ^^^
...
256 |                 assert!(!ptr.is_null());
    |                          --- type must be known at this point
    |
help: consider giving `arr` an explicit type, where the placeholders `_` are specified
    |
252 |             let arr: &[T] = unsafe {
    |                    ++++++

error[E0615]: attempted to take value of method `iformat` on type `&'stream AVFormatContextInput`
   --> src/avformat/avformat.rs:267:63
    |
267 |         unsafe { AVInputFormatRef::from_raw(NonNull::new(self.iformat as *mut _).unwrap()) }
    |                                                               ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
267 |         unsafe { AVInputFormatRef::from_raw(NonNull::new(self.iformat() as *mut _).unwrap()) }
    |                                                                      ++

error[E0615]: attempted to take value of method `metadata` on type `&'stream AVFormatContextInput`
   --> src/avformat/avformat.rs:277:27
    |
277 |         NonNull::new(self.metadata).map(|x| unsafe { AVDictionaryRef::from_raw(x) })
    |                           ^^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
277 |         NonNull::new(self.metadata()).map(|x| unsafe { AVDictionaryRef::from_raw(x) })
    |                                   ++

error[E0609]: no field `pb` on type `&mut AVFormatContext`
   --> src/avformat/avformat.rs:359:55
    |
359 |                     output_format_context.deref_mut().pb = io_context.as_mut_ptr();
    |                                                       ^^ unknown field
    |
    = note: available field is: `_address`

error[E0615]: attempted to take value of method `streams` on type `&'stream AVFormatContextOutput`
   --> src/avformat/avformat.rs:446:28
    |
446 |         let streams = self.streams as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
    |                            ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
446 |         let streams = self.streams() as *const *const ffi::AVStream as *const AVStreamRef<'stream>;
    |                                   ++

error[E0609]: no field `nb_streams` on type `&'stream AVFormatContextOutput`
   --> src/avformat/avformat.rs:448:24
    |
448 |         let len = self.nb_streams as usize;
    |                        ^^^^^^^^^^ unknown field
    |
    = note: available fields are: `something_should_not_be_touched_directly`, `io_context`
    = note: available field is: `_address`

error[E0615]: attempted to take value of method `streams` on type `&'stream AVFormatContextOutput`
   --> src/avformat/avformat.rs:454:49
    |
454 |                 std::slice::from_raw_parts(self.streams as *const *const ffi::AVStream, len)
    |                                                 ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
454 |                 std::slice::from_raw_parts(self.streams() as *const *const ffi::AVStream, len)
    |                                                        ++

error[E0282]: type annotations needed for `&[_]`
   --> src/avformat/avformat.rs:453:17
    |
453 |             let arr = unsafe {
    |                 ^^^
...
457 |                 assert!(!ptr.is_null());
    |                          --- type must be known at this point
    |
help: consider giving `arr` an explicit type, where the placeholders `_` are specified
    |
453 |             let arr: &[T] = unsafe {
    |                    ++++++

error[E0615]: attempted to take value of method `oformat` on type `&AVFormatContextOutput`
   --> src/avformat/avformat.rs:468:64
    |
468 |         unsafe { AVOutputFormatRef::from_raw(NonNull::new(self.oformat as *mut _).unwrap()) }
    |                                                                ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
468 |         unsafe { AVOutputFormatRef::from_raw(NonNull::new(self.oformat() as *mut _).unwrap()) }
    |                                                                       ++

error[E0609]: no field `oformat` on type `&mut AVFormatContext`
   --> src/avformat/avformat.rs:475:30
    |
475 |             self.deref_mut().oformat = format.as_ptr() as _;
    |                              ^^^^^^^ unknown field
    |
    = note: available field is: `_address`

error[E0615]: attempted to take value of method `oformat` on type `&mut AVFormatContextOutput`
   --> src/avformat/avformat.rs:496:27
    |
496 |         if unsafe { *self.oformat }.flags & ffi::AVFMT_NOFILE as i32 == 0 {
    |                           ^^^^^^^ method, not a field
    |
help: use parentheses to call the method
    |
496 |         if unsafe { *self.oformat() }.flags & ffi::AVFMT_NOFILE as i32 == 0 {
    |                                  ++

error[E0609]: no field `pb` on type `&mut AVFormatContextOutput`
   --> src/avformat/avformat.rs:497:49
    |
497 |             if let Some(pb) = NonNull::new(self.pb) {
    |                                                 ^^ unknown field
    |
    = note: available fields are: `something_should_not_be_touched_directly`, `io_context`
    = note: available field is: `_address`

Some errors have detailed explanations: E0282, E0609, E0615.
For more information about an error, try `rustc --explain E0282`.
error: could not compile `rsmpeg` (lib) due to 21 previous errors
```

Tests compile, but still do not pass after my fixes. I have never worked with ffmpeg's ffi so I'd be grateful if you could give a second look. At the time of writing I am still working on fixing the tests, I will update the PR accordingly.

Edit: the only failing test is misc::frame_image_copy_to_buffer::test_frame_copy_to_buffer0, but I am not sure if the problem is in the ground-truth file which output is not byte-identical to the one given by the last vcpkg release or if it's due to a problem in the code. It could be useful to pin a specific vcpkg commit for each rsmpeg release.